### PR TITLE
feat: add start tour form and API endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,34 @@
+import http from "http";
+
+const server = http.createServer((req, res) => {
+  if (req.method === "POST" && req.url === "/tours") {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      try {
+        const data = JSON.parse(body || "{}");
+        if (!data.date || !Array.isArray(data.orders)) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Invalid payload" }));
+          return;
+        }
+        res.writeHead(201, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ message: "Tour created" }));
+      } catch {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid JSON" }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,9 @@
 import { createContext, useState } from "react";
 import { Routes, Route } from "react-router-dom";
+import StartTourForm from "./components/StartTourForm";
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const GlobalContext = createContext();
-
-function StartTour() {
-  return <div>Start Tour</div>;
-}
 
 function EndTour() {
   return <div>End Tour</div>;
@@ -18,7 +15,7 @@ function App() {
   return (
     <GlobalContext.Provider value={{ state, setState }}>
       <Routes>
-        <Route path="/start-tour" element={<StartTour />} />
+        <Route path="/start-tour" element={<StartTourForm />} />
         <Route path="/end-tour" element={<EndTour />} />
       </Routes>
     </GlobalContext.Provider>

--- a/frontend/src/components/StartTourForm.jsx
+++ b/frontend/src/components/StartTourForm.jsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+
+function StartTourForm() {
+  const [date, setDate] = useState("");
+  const [orders, setOrders] = useState([
+    { customer: "", standardParcels: "", cartons: "" },
+  ]);
+  const [errors, setErrors] = useState({});
+
+  const handleOrderChange = (index, field, value) => {
+    const next = orders.map((o, i) =>
+      i === index ? { ...o, [field]: value } : o
+    );
+    setOrders(next);
+  };
+
+  const addOrder = () => {
+    setOrders([...orders, { customer: "", standardParcels: "", cartons: "" }]);
+  };
+
+  const removeOrder = (index) => {
+    setOrders(orders.filter((_, i) => i !== index));
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    if (!date) newErrors.date = "Date requise";
+    orders.forEach((o, i) => {
+      if (!o.customer) newErrors[`customer-${i}`] = "Requis";
+      if (o.standardParcels === "" || isNaN(Number(o.standardParcels))) {
+        newErrors[`standardParcels-${i}`] = "Nombre requis";
+      }
+      if (o.cartons === "" || isNaN(Number(o.cartons))) {
+        newErrors[`cartons-${i}`] = "Nombre requis";
+      }
+    });
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    try {
+      const res = await fetch("/tours", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date, orders }),
+      });
+      if (!res.ok) throw new Error("Network response was not ok");
+      alert("Tournée créée");
+      setDate("");
+      setOrders([{ customer: "", standardParcels: "", cartons: "" }]);
+    } catch (err) {
+      console.error(err);
+      alert("Erreur lors de la création de la tournée");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>
+          Date:
+          <input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+        </label>
+        {errors.date && <span>{errors.date}</span>}
+      </div>
+      {orders.map((o, i) => (
+        <div key={i}>
+          <input
+            type="text"
+            placeholder="Donneur d'ordre"
+            value={o.customer}
+            onChange={(e) => handleOrderChange(i, "customer", e.target.value)}
+          />
+          {errors[`customer-${i}`] && <span>{errors[`customer-${i}`]}</span>}
+          <input
+            type="number"
+            min="0"
+            placeholder="Colis standards"
+            value={o.standardParcels}
+            onChange={(e) => handleOrderChange(i, "standardParcels", e.target.value)}
+          />
+          {errors[`standardParcels-${i}`] && <span>{errors[`standardParcels-${i}`]}</span>}
+          <input
+            type="number"
+            min="0"
+            placeholder="Cartons"
+            value={o.cartons}
+            onChange={(e) => handleOrderChange(i, "cartons", e.target.value)}
+          />
+          {errors[`cartons-${i}`] && <span>{errors[`cartons-${i}`]}</span>}
+          <button type="button" onClick={() => removeOrder(i)}>
+            Supprimer
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={addOrder}>
+        Ajouter un donneur d'ordre
+      </button>
+      <button type="submit">Démarrer la tournée</button>
+    </form>
+  );
+}
+
+export default StartTourForm;
+


### PR DESCRIPTION
## Summary
- add StartTourForm with date, order list and validation
- route start tour form in frontend
- implement HTTP POST /tours endpoint

## Testing
- `npm test` (fails: Missing script: "test")
- `npm --prefix frontend test` (fails: Missing script: "test")
- `npm --prefix frontend run lint`
- `node backend/server.js & pid=$!; sleep 1; curl -s -X POST -H 'Content-Type: application/json' -d '{"date":"2024-01-01","orders":[]}' http://localhost:3000/tours; echo; kill $pid`

------
https://chatgpt.com/codex/tasks/task_e_688f6be807b0832cb27153defdb2482b